### PR TITLE
spec: align simplex-en v0.1 with Option A auxiliaries

### DIFF
--- a/examples/v0.1-sentences.md
+++ b/examples/v0.1-sentences.md
@@ -3,10 +3,12 @@
 ## simplex-en
 
 - `mi see dog`
-- `mi seed dog`
-- `mi seel dog`
+- `mi did see dog`
+- `mi will see dog`
 - `mi not see dog`
-- `qa mi see dog`
+- `do yu see dog`
+- `did yu see dog`
+- `will yu see dog`
 - `mi see dogs`
 - `teach-er`
 - `un-clear`

--- a/spec/framework-v0.1.md
+++ b/spec/framework-v0.1.md
@@ -48,11 +48,19 @@ Every variant MUST implement these meanings:
 - **FUTURE** — action/state occurs in the future
 - **PRESENT** — default/unmarked
 
+Notes:
+- Tense may be implemented as affixes or auxiliary particles.
+- For `simplex-en` v0.1 we currently prefer **auxiliaries** (e.g. `did`, `will`).
+
 ### 2.3 Polarity
 - **NEGATION** — logical negation of a clause ("not")
 
 ### 2.4 Interrogative
 - **QUESTION** — marks a clause as a yes/no question
+
+Notes:
+- A variant may implement QUESTIONS as a dedicated particle (e.g. `qa`) **or** with auxiliary inversion (e.g. `do/did/will`).
+- The chosen form must be regular and deterministic within the variant.
 
 ### 2.5 Derivation (word-building)
 - **AGENT** — “person/thing that does X” (doer)
@@ -71,11 +79,11 @@ The framework does **not** mandate whether a meaning is expressed as:
 A variant is v0.1-compliant if it can express the following without exceptions:
 
 1. `I see dog.`
-2. `I saw dog.`
-3. `I will see dog.`
-4. `I do not see dog.`
-5. `Do I see dog?` (yes/no question)
-6. `I see dogs.`
+2. `I did see dog.` (PAST)
+3. `I will see dog.` (FUTURE)
+4. `I not see dog.` (NEGATION)
+5. `Do you see dog?` (QUESTION)
+6. `I see dogs.` (PLURAL)
 7. `teacher` (AGENT(teach))
 8. `unclear` (OPPOSITE(clear))
 

--- a/variants/simplex-en/README.md
+++ b/variants/simplex-en/README.md
@@ -10,19 +10,30 @@ English-flavored simplex variant.
 - Clause order: SVO
 - Adjectives: pre-nominal
 - NEGATION: particle `not`
-- QUESTION: particle `qa` at clause start
+- YES/NO QUESTIONS: `do/did/will` auxiliaries (English-like)
 
-## Affixes (draft)
+## Affixes and particles (draft)
 
 These realize the shared meaning map for v0.1.
 
 ### Number
 - PLURAL: noun suffix `-s`
 
-### Tense
-- PAST: verb suffix `-d`
-- FUTURE: verb suffix `-l`
-- PRESENT: unmarked
+### Tense (verbs)
+
+Tense is expressed with **auxiliary particles** (not verb suffixes):
+
+- PRESENT: bare verb
+- PAST: `did` + verb
+- FUTURE: `will` + verb
+
+### Interrogative (yes/no)
+
+Questions use an auxiliary at clause start:
+
+- PRESENT: `do` + subject + verb
+- PAST: `did` + subject + verb
+- FUTURE: `will` + subject + verb
 
 ### Derivation
 - AGENT: suffix `-er`
@@ -31,10 +42,12 @@ These realize the shared meaning map for v0.1.
 ## Examples
 
 - `mi see dog` — I see dog.
-- `mi seed dog` — I saw dog.
-- `mi seel dog` — I will see dog.
+- `mi did see dog` — I saw dog.
+- `mi will see dog` — I will see dog.
 - `mi not see dog` — I do not see dog.
-- `qa mi see dog` — Do I see dog?
+- `do yu see dog` — Do you see dog?
+- `did yu see dog` — Did you see dog?
+- `will yu see dog` — Will you see dog?
 - `mi see dogs` — I see dogs.
 - `teach-er` — teacher
 - `un-clear` — unclear


### PR DESCRIPTION
Fixes #2\n\nUpdates simplex-en to use English-like auxiliaries for tense and questions (do/did/will), and refreshes examples + framework notes accordingly.